### PR TITLE
fix: prevent exceeding kMaxContextLen from crashing the app

### DIFF
--- a/examples/models/llama/runner/runner.cpp
+++ b/examples/models/llama/runner/runner.cpp
@@ -216,7 +216,7 @@ Error Runner::generate(
   } else if (num_prompt_tokens >= seq_len) {
     ET_LOG(Error,
            "num_prompt_tokens %d >= seq_len %d, Sequence length exceeded - "
-           "please increate the seq_len value papsed to generate()!",
+           "please increase the seq_len value passed to generate()!",
            num_prompt_tokens, seq_len);
     return Error::InvalidArgument;
   }

--- a/examples/models/llama/runner/runner.cpp
+++ b/examples/models/llama/runner/runner.cpp
@@ -196,9 +196,9 @@ Error Runner::generate(
   shouldStop_ = false;
 
   // Set the sequence length to the max seq length if not provided
-  seq_len = (seq_len > 0 && seq_len <= metadata_.at(kMaxContextLen))
+  seq_len = (seq_len > 0 && seq_len <= metadata_.at(kMaxSeqLen))
       ? seq_len
-      : metadata_.at(kMaxContextLen);
+      : metadata_.at(kMaxSeqLen);
 
   std::vector<int32_t> prompt_tokens = tokenizer_->Encode(prompt);
   std::vector<uint64_t> prompt_tokens_uint64(
@@ -207,18 +207,19 @@ Error Runner::generate(
   // encode the (string) prompt into tokens sequence
   int num_prompt_tokens = prompt_tokens.size();
 
-  ET_CHECK_MSG(num_prompt_tokens >= 1, "Expected at least 1 prompt token");
-  ET_CHECK_MSG(
-      num_prompt_tokens < metadata_.at(kMaxSeqLen),
-      "num_prompt_tokens %d >= max_seq_len_ %" PRId64
-      ", Max seq length exceeded - please increase max seq len value in .../llama2/model.py",
-      num_prompt_tokens,
-      metadata_.at(kMaxSeqLen));
-  ET_CHECK_MSG(
-      num_prompt_tokens < seq_len,
-      "num_prompt_tokens %d >= seq_len %d, Sequence length exceeded - please increase the seq_len value passed to generate()",
-      num_prompt_tokens,
-      seq_len);
+  if (num_prompt_tokens < 1) {
+    ET_LOG(Error,
+           "num_prompt_tokens %d < 1, expected at least 1 token to be passed "
+           "to generate()!",
+           num_prompt_tokens);
+    return Error::InvalidArgument;
+  } else if (num_prompt_tokens >= seq_len) {
+    ET_LOG(Error,
+           "num_prompt_tokens %d >= seq_len %d, Sequence length exceeded - "
+           "please increate the seq_len value papsed to generate()!",
+           num_prompt_tokens, seq_len);
+    return Error::InvalidArgument;
+  }
 
   // Prefill first
   // Here feed all tokens to the model and get the next predicted token


### PR DESCRIPTION
This PR deletes the use of macro which aborted the ET runtime when the length of the prompt exceeds the `kMaxContextLen`. Instead of aborting an error is returned to the end user and `ET_LOG` is made as well. 